### PR TITLE
admin manage orders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- "stable"

--- a/app/models/orders.json
+++ b/app/models/orders.json
@@ -29,7 +29,7 @@
     "_recipientPhone": "250784834836",
     "_initiatorId": 1,
     "_deliveryDate": "",
-    "_status": "Created",
+    "_status": "delivered",
     "_weight": 0
   }
 }

--- a/app/routes/orders.js
+++ b/app/routes/orders.js
@@ -69,4 +69,21 @@ router.get('/:id', (req, res) => {
   }
 });
 
+router.put('/:id/cancel', (req, res) => {
+  const id = req.params.id;
+  const order = orders[id];
+  if (order._status !== 'delivered') {
+    order._status = 'canceled';
+    return res.status(200).send({
+      success: true,
+      message: 'delivery order has been canceled',
+    });
+  } else {
+    return res.status(401).send({
+      success: false,
+      message: 'cannot cancel a delivered order',
+    });
+  }
+});
+
 export default router;

--- a/test/test-orders.js
+++ b/test/test-orders.js
@@ -160,6 +160,48 @@ const cannotGetOrderById = (done) => {
       done();
     });
 };
+
+const canCannotCancelOrder = (done) => {
+  /**
+   * test if we cannot cancel a delivery order if the status
+   * marked as delivered
+   * in the future we need to allow only admin or a person who create order to implement
+   */
+  const id = 1;
+  const order = orders[id.toString()];
+  order._status = 'delivered';
+  chai
+    .request(app)
+    .put(`/api/v1/parcels/${id}/cancel `)
+    .end((request, response) => {
+      response.should.have.status(401);
+      response.body.should.be.a('object');
+      response.body.should.have.property('success').eql(false);
+      response.body.should.have.property('message').eql('cannot cancel a delivered order');
+      done();
+    });
+};
+
+const canCancelOrder = (done) => {
+  /**
+   * test if we cancel a delivery order if the status
+   * marked is not  delivered
+   */
+  const id = 1;
+  const order = orders[id.toString()];
+  order._status = 'canceled';
+  chai
+    .request(app)
+    .put(`/api/v1/parcels/${id}/cancel `)
+    .end((request, response) => {
+      response.should.have.status(200);
+      response.body.should.be.a('object');
+      response.body.should.have.property('success').eql(true);
+      response.body.should.have.property('message').eql('delivery order has been canceled');
+      done();
+    });
+};
+
 /*
   * Test the /POST route for creating new book
   */
@@ -175,6 +217,12 @@ describe('create orders', () => {
 describe('get order by id', () => {
   it('can get order by id', canGetOrderById);
   it('cannot get order if  id invalid', cannotGetOrderById);
+});
+
+// test cancel order
+describe('can cancel order', () => {
+  it('can cancel order by id', canCancelOrder);
+  it('cannot cancel if delivered', canCannotCancelOrder);
 });
 
 it('return all orders as json', returnAllOrders);


### PR DESCRIPTION
## Description

An admin is now able to cancel package delivery order
.travis.yml file added in the project repo

## Type of change
- [ ] Admin can manage orders

## How Has This Been Tested?

This functionality has been tested by mocha and chai, please refer to the folder test for more details

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
